### PR TITLE
[WIP] refactor: use electron-menubar instead of menubar

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "electron-compile": "^6.4.2",
     "electron-is-dev": "^0.3.0",
-    "electron-menubar": "^1.0.0",
+    "electron-menubar": "^1.0.1",
     "electron-squirrel-startup": "^1.0.0",
     "file-extension": "^4.0.0",
     "ipfs-geoip": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "electron-compile": "^6.4.2",
     "electron-is-dev": "^0.3.0",
-    "electron-menubar": "^0.0.10",
+    "electron-menubar": "^0.0.12",
     "electron-squirrel-startup": "^1.0.0",
     "file-extension": "^4.0.0",
     "ipfs-geoip": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "electron-compile": "^6.4.2",
     "electron-is-dev": "^0.3.0",
-    "electron-menubar": "^0.0.12",
+    "electron-menubar": "^1.0.0",
     "electron-squirrel-startup": "^1.0.0",
     "file-extension": "^4.0.0",
     "ipfs-geoip": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "electron-compile": "^6.4.2",
     "electron-is-dev": "^0.3.0",
-    "electron-menubar": "^0.0.8",
+    "electron-menubar": "^0.0.10",
     "electron-squirrel-startup": "^1.0.0",
     "file-extension": "^4.0.0",
     "ipfs-geoip": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -8,11 +8,11 @@
   "dependencies": {
     "electron-compile": "^6.4.2",
     "electron-is-dev": "^0.3.0",
+    "electron-menubar": "^0.0.6",
     "electron-squirrel-startup": "^1.0.0",
     "file-extension": "^4.0.0",
     "ipfs-geoip": "^2.3.0",
     "ipfsd-ctl": "^0.26.0",
-    "menubar": "^5.2.3",
     "moment": "^2.19.3",
     "multiaddr": "^3.0.1",
     "normalize.css": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "electron-compile": "^6.4.2",
     "electron-is-dev": "^0.3.0",
-    "electron-menubar": "^0.0.6",
+    "electron-menubar": "^0.0.8",
     "electron-squirrel-startup": "^1.0.0",
     "file-extension": "^4.0.0",
     "ipfs-geoip": "^2.3.0",

--- a/src/config.js
+++ b/src/config.js
@@ -89,18 +89,20 @@ export default {
   },
   menubar: {
     dir: __dirname,
-    width: 850,
-    height: 400,
-    backgroundColor: '#000000',
     index: `file://${__dirname}/views/menubar.html`,
     icon: logo('black'),
     tooltip: 'Your IPFS instance',
     preloadWindow: true,
-    resizable: false,
-    skipTaskbar: true,
-    webPreferences: {
-      nodeIntegration: true,
-      webSecurity: false
+    window: {
+      resizable: false,
+      skipTaskbar: true,
+      width: 850,
+      height: 400,
+      backgroundColor: '#000000',
+      webPreferences: {
+        nodeIntegration: true,
+        webSecurity: false
+      }
     }
   },
   ipfsPath: ipfsPath,

--- a/src/config.js
+++ b/src/config.js
@@ -88,7 +88,6 @@ export default {
     black: logo('black')
   },
   menubar: {
-    dir: __dirname,
     index: `file://${__dirname}/views/menubar.html`,
     icon: logo('black'),
     tooltip: 'Your IPFS instance',

--- a/src/controls/main/toggle-sticky.js
+++ b/src/controls/main/toggle-sticky.js
@@ -8,7 +8,6 @@ export default function (opts) {
   ipcMain.on('toggle-sticky', () => {
     sticky = !sticky
     menubar.window.setAlwaysOnTop(sticky)
-    menubar.setOption('alwaysOnTop', sticky)
     send('sticky-window', sticky)
   })
 }

--- a/src/index.js
+++ b/src/index.js
@@ -133,7 +133,7 @@ function initialize (path, node) {
   mb.window.webContents.on('did-finish-load', () => {
     send('setup-config-path', path)
   })
-  mb.showWindow()
+  mb.show()
 
   // Close the application if the welcome dialog is canceled
   mb.window.once('close', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import Menubar from 'electron-menubar'
+import {Menubar} from 'electron-menubar'
 import fs from 'fs'
 import ipfsd from 'ipfsd-ctl'
 import {join} from 'path'
@@ -196,9 +196,7 @@ ipfsd.local((err, node) => {
     process.exit(1)
   }
 
-  mb = new Menubar(config.menubar)
-
-  mb.on('ready', () => {
+  let appReady = () => {
     logger.info('Application is ready')
     mb.tray.setHighlightMode(true)
 
@@ -224,5 +222,10 @@ ipfsd.local((err, node) => {
       // Start up the daemon
       onStartDaemon(node)
     }
-  })
+  }
+
+  mb = new Menubar(config.menubar)
+
+  if (mb.isReady()) appReady()
+  else mb.on('ready', appReady)
 })

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import menubar from 'menubar'
+import Menubar from 'electron-menubar'
 import fs from 'fs'
 import ipfsd from 'ipfsd-ctl'
 import {join} from 'path'
@@ -196,7 +196,7 @@ ipfsd.local((err, node) => {
     process.exit(1)
   }
 
-  mb = menubar(config.menubar)
+  mb = new Menubar(config.menubar)
 
   mb.on('ready', () => {
     logger.info('Application is ready')


### PR DESCRIPTION
I'm building a small module called 'electron-menubar' which is based on 'menubar', but with its code cleaned and a simpler API and a bunch of bugs fixed (like the correct position on Linux distributions).