### PR TITLE
feat: download copied hash

### DIFF
--- a/src/controls/main/download-hash.js
+++ b/src/controls/main/download-hash.js
@@ -53,8 +53,14 @@ function handler (opts) {
 
     ipfs().get(text)
       .then((files) => {
+        logger.info(`Hash ${text} downloaded.`)
         selectDirectory(opts)
           .then((dir) => {
+            if (!dir) {
+              logger.info(`Dropping hash ${text}: user didn't choose a path.`)
+              return
+            }
+
             if (files.length > 1) {
               fs.mkdirSync(path.join(dir, text))
             }

--- a/src/controls/main/download-hash.js
+++ b/src/controls/main/download-hash.js
@@ -1,0 +1,87 @@
+import {clipboard, app, dialog, globalShortcut} from 'electron'
+import path from 'path'
+import fs from 'fs'
+
+const settingsOption = 'downloadHashShortcut'
+const shortcut = 'CommandOrControl+Alt+D'
+
+function selectDirectory (opts) {
+  const {menubar} = opts
+
+  return new Promise((resolve, reject) => {
+    dialog.showOpenDialog(menubar.window, {
+      title: 'Select a directory',
+      defaultPath: app.getPath('downloads'),
+      properties: [
+        'openDirectory',
+        'createDirectory'
+      ]
+    }, (res) => {
+      if (!res) resolve()
+      resolve(res[0])
+    })
+  })
+}
+
+function saveFile (opts, dir, file) {
+  const {logger} = opts
+  const location = path.join(dir, file.path)
+
+  if (fs.existsSync(location)) {
+    // Ignore the hash itself.
+    return
+  }
+
+  fs.writeFile(location, file.content, (err) => {
+    if (err) {
+      logger.error(err.stack)
+    } else {
+      logger.info(`File '${file.path}' downloaded to ${location}.`)
+    }
+  })
+}
+
+function handler (opts) {
+  const {logger, ipfs} = opts
+
+  return () => {
+    const text = clipboard.readText().trim()
+
+    if (!ipfs() || !text) {
+      return
+    }
+
+    ipfs().get(text)
+      .then((files) => {
+        selectDirectory(opts)
+          .then((dir) => {
+            if (files.length > 1) {
+              fs.mkdirSync(path.join(dir, text))
+            }
+
+            files.forEach(file => { saveFile(opts, dir, file) })
+          })
+          .catch(e => logger.error(e.stack))
+      })
+      .catch(e => logger.warn(e.stack))
+  }
+}
+
+export default function (opts) {
+  let {logger, settingsStore} = opts
+
+  let activate = (value, oldValue) => {
+    if (value === oldValue) return
+
+    if (value === true) {
+      globalShortcut.register(shortcut, handler(opts))
+      logger.info('Hash download shortcut enabled')
+    } else {
+      globalShortcut.unregister(shortcut)
+      logger.info('Hash download shortcut disabled')
+    }
+  }
+
+  activate(settingsStore.get(settingsOption))
+  settingsStore.on(settingsOption, activate)
+}

--- a/src/controls/main/index.js
+++ b/src/controls/main/index.js
@@ -1,4 +1,5 @@
 import autoLaunch from './auto-launch'
+import downloadHash from './download-hash'
 import fileHistory from './file-history'
 import openFileDialog from './open-file-dialog'
 import openWebUI from './open-webui'
@@ -9,6 +10,7 @@ import uploadFiles from './upload-files'
 
 export default function (opts) {
   autoLaunch(opts)
+  downloadHash(opts)
   fileHistory(opts)
   openFileDialog(opts)
   openWebUI(opts)

--- a/src/controls/utils.js
+++ b/src/controls/utils.js
@@ -13,7 +13,7 @@ export function uploadFiles (opts) {
 
   return (event, files) => {
     ipfs()
-      .add(files, {recursive: true, w: files.length > 1})
+      .add(files, {recursive: true, wrap: true})
       .then((res) => {
         logger.info('Uploading files', {files})
 

--- a/src/js/screens/settings.js
+++ b/src/js/screens/settings.js
@@ -64,6 +64,17 @@ export default class Settings extends Component {
               <span className='key'>ALT</span> + <span className='key'>S</span> <span />
               shortcut</span>
             )} />
+
+          <CheckboxItem
+            title='Download copied hash'
+            id='downloadHashShortcut'
+            onChange={this._generateOnChange('downloadHashShortcut')}
+            value={this.state.downloadHashShortcut}
+            info={(<span>
+              Download copied hash with <span className='key'>CTRL/CMD</span> + <span />
+              <span className='key'>ALT</span> + <span className='key'>D</span> <span />
+              shortcut</span>
+            )} />
         </div>
 
         <Footer>


### PR DESCRIPTION
With this PR you can now activate the `CTRL/CMD`+`ALT`+`D`  shortcut to download the hash you've copied into your clipboard.