### PR TITLE
Add MIT license to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,4 +157,6 @@ This repository falls under the IPFS [Code of Conduct](https://github.com/ipfs/c
 
 ## License
 
+[MIT 2016 Protocol Labs, Inc.](./LICENSE)
+
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fipfs%2Fstation.svg?type=large)](https://app.fossa.io/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fipfs%2Fstation?ref=badge_large)


### PR DESCRIPTION
FOSSA badge doesn't actually show which license is being used.